### PR TITLE
Fix linker issues when cross-compiling for Windows

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -152,7 +152,7 @@ impl IpAdapterAddresses {
     }
 }
 
-#[link(name = "Iphlpapi")]
+#[link(name = "iphlpapi")]
 extern "system" {
     fn GetAdaptersAddresses(
         family: ULONG,


### PR DESCRIPTION
Thanks a lot for providing this nice library and maintained alternative to [get_if_addrs](https://crates.io/crates/get_if_addrs) 👍 

I ran into problems when cross-compiling from Linux to Windows with the mingw-w64 toolchain, which provides `iphlpapi.lib` with an all-lowercase filename. This change is to change the dependency to all-lowercase, which won't affect the native build on Windows.

The lib name is lowercase also in the Windows SDK, which contradicts the information in the [MS docs](https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses).